### PR TITLE
Ported to python3 and used underscores in package name for easier importing

### DIFF
--- a/cloudify_rest_client/blueprints.py
+++ b/cloudify_rest_client/blueprints.py
@@ -16,8 +16,8 @@
 import os
 import tempfile
 import shutil
-import urllib
-import urlparse
+import urllib.request, urllib.parse, urllib.error
+import urllib.parse
 import contextlib
 
 from cloudify_rest_client import utils
@@ -95,13 +95,13 @@ class BlueprintsClient(object):
         query_params = {'visibility': visibility}
         if application_file_name is not None:
             query_params['application_file_name'] = \
-                urllib.quote(application_file_name)
+                urllib.parse.quote(application_file_name)
 
         uri = '/{self._uri_prefix}/{id}'.format(self=self, id=blueprint_id)
 
         # For a Windows path (e.g. "C:\aaa\bbb.zip") scheme is the
         # drive letter and therefore the 2nd condition is present
-        if urlparse.urlparse(archive_location).scheme and \
+        if urllib.parse.urlparse(archive_location).scheme and \
                 not os.path.exists(archive_location):
             # archive location is URL
             query_params['blueprint_archive_url'] = archive_location

--- a/cloudify_rest_client/client.py
+++ b/cloudify_rest_client/client.py
@@ -162,13 +162,13 @@ class HTTPClient(object):
                                    timeout=timeout or self.default_timeout_sec,
                                    auth=auth)
         if self.logger.isEnabledFor(logging.DEBUG):
-            for hdr, hdr_content in response.request.headers.iteritems():
+            for hdr, hdr_content in list(response.request.headers.items()):
                 self.logger.debug('request header:  %s: %s'
                                   % (hdr, hdr_content))
             self.logger.debug('reply:  "%s %s" %s'
                               % (response.status_code,
                                  response.reason, response.content))
-            for hdr, hdr_content in response.headers.iteritems():
+            for hdr, hdr_content in list(response.headers.items()):
                 self.logger.debug('response header:  %s: %s'
                                   % (hdr, hdr_content))
 
@@ -227,7 +227,7 @@ class HTTPClient(object):
         body = json.dumps(data) if is_dict_data else data
         if self.logger.isEnabledFor(logging.DEBUG):
             log_message = 'Sending request: {0} {1}'.format(
-                requests_method.func_name.upper(),
+                requests_method.__name__.upper(),
                 request_url)
             if is_dict_data:
                 log_message += '; body: {0}'.format(body)

--- a/cloudify_rest_client/client.py
+++ b/cloudify_rest_client/client.py
@@ -317,7 +317,7 @@ class HTTPClient(object):
         if not username or not password:
             return None
         credentials = '{0}:{1}'.format(username, password)
-        encoded_credentials = urlsafe_b64encode(credentials)
+        encoded_credentials = urlsafe_b64encode(credentials.encode('utf-8')).decode('utf-8')
         return BASIC_AUTH_PREFIX + ' ' + encoded_credentials
 
     def _set_header(self, key, value, log_value=True):

--- a/cloudify_rest_client/client.py
+++ b/cloudify_rest_client/client.py
@@ -77,7 +77,6 @@ class HTTPClient(object):
         self.host = host
         self.protocol = protocol
         self.api_version = api_version
-
         self.headers = headers.copy() if headers else {}
         if not self.headers.get('Content-type'):
             self.headers['Content-type'] = 'application/json'

--- a/cloudify_rest_client/deployment_updates.py
+++ b/cloudify_rest_client/deployment_updates.py
@@ -15,9 +15,9 @@
 
 import os
 import json
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import shutil
-import urlparse
+import urllib.parse
 import tempfile
 
 from mimetypes import MimeTypes
@@ -149,11 +149,11 @@ class DeploymentUpdatesClient(object):
 
         if application_file_name:
             params['application_file_name'] = \
-                urllib.quote(application_file_name)
+                urllib.parse.quote(application_file_name)
 
         # For a Windows path (e.g. "C:\aaa\bbb.zip") scheme is the
         # drive letter and therefore the 2nd condition is present
-        if all([urlparse.urlparse(archive_path).scheme,
+        if all([urllib.parse.urlparse(archive_path).scheme,
                 not os.path.exists(archive_path)]):
             # archive location is URL
             params['blueprint_archive_url'] = archive_path
@@ -162,7 +162,7 @@ class DeploymentUpdatesClient(object):
                 os.path.basename(archive_path),
                 open(archive_path, 'rb'),
                 # Guess the archive mime type
-                mime_types.guess_type(urllib.pathname2url(archive_path)))
+                mime_types.guess_type(urllib.request.pathname2url(archive_path)))
 
         return data_form, params
 

--- a/cloudify_rest_client/exceptions.py
+++ b/cloudify_rest_client/exceptions.py
@@ -23,10 +23,12 @@ class CloudifyClientError(Exception):
         self.error_code = error_code
         self.server_traceback = server_traceback
         self.response = response
+        self.message = message
 
     def __str__(self):
         if self.status_code != -1:
-            return '{0}: {1}'.format(self.status_code, self.message)
+            formatted_error = '{0}: {1}'.format(self.status_code, self.message)
+            return formatted_error
         return self.message
 
 

--- a/cloudify_rest_client/plugins.py
+++ b/cloudify_rest_client/plugins.py
@@ -14,7 +14,7 @@
 #    * limitations under the License.
 
 import os
-import urlparse
+import urllib.parse
 import contextlib
 
 from cloudify_rest_client import bytes_stream_utils
@@ -222,7 +222,7 @@ class PluginsClient(object):
         assert plugin_path
         query_params = {'visibility': visibility}
         timeout = self.api.default_timeout_sec
-        if urlparse.urlparse(plugin_path).scheme and \
+        if urllib.parse.urlparse(plugin_path).scheme and \
                 not os.path.exists(plugin_path):
             query_params['plugin_archive_url'] = plugin_path
             data = None

--- a/cloudify_rest_client/secrets.py
+++ b/cloudify_rest_client/secrets.py
@@ -124,7 +124,7 @@ class SecretsClient(object):
         }
 
         # Remove the keys with value None
-        data = dict((k, v) for k, v in data.iteritems() if v is not None)
+        data = dict((k, v) for k, v in list(data.items()) if v is not None)
         response = self.api.patch('/secrets/{0}'.format(key), data=data)
         return Secret(response)
 

--- a/cloudify_rest_client/snapshots.py
+++ b/cloudify_rest_client/snapshots.py
@@ -14,7 +14,7 @@
 #    * limitations under the License.
 
 import os
-import urlparse
+import urllib.parse
 import contextlib
 
 from cloudify_rest_client import bytes_stream_utils
@@ -192,7 +192,7 @@ class SnapshotsClient(object):
         uri = '/snapshots/{0}/archive'.format(snapshot_id)
         query_params = {}
 
-        if urlparse.urlparse(snapshot_path).scheme and \
+        if urllib.parse.urlparse(snapshot_path).scheme and \
                 not os.path.exists(snapshot_path):
             query_params['snapshot_archive_url'] = snapshot_path
             data = None

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='cloudify-rest-client',
+    name='cloudify_rest_client',
     version='4.4.dev1',
     author='cosmo-admin',
     author_email='cosmo-admin@gigaspaces.com',


### PR DESCRIPTION
This should fix #97 by giving python3 support (the changes were made using the 2to3 script and tested in my machine not very thoroughly). Also, since the name of the package was defined using hyphens instead of underscores, importing required special syntax. The setup.py file was updated to use the new name "cloudify_rest_client".